### PR TITLE
feat: support passing the complete file to instead of the crash lines

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,11 @@
 const {argv} = require('yargs')
 const atos = require('./index')
 
-atos(argv, (error, output) => {
+atos(argv, (error, symbolicated) => {
   if (error != null) {
     console.error(error.stack || error.message)
     process.exit(1)
   } else {
-    console.log(`Symbols successfully written to ${output} file.`)
+    console.log(symbolicated.join('\n'))
   }
 })

--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,11 @@
 const {argv} = require('yargs')
 const atos = require('./index')
 
-atos(argv, (error, symbols) => {
+atos(argv, (error, output) => {
   if (error != null) {
     console.error(error.stack || error.message)
     process.exit(1)
   } else {
-    console.log(symbols.join('\n'))
+    console.log(`Symbols successfully written to ${output} file.`)
   }
 })

--- a/index.js
+++ b/index.js
@@ -36,11 +36,7 @@ module.exports = (options, callback) => {
       concatted.map((sym) => {
         split[sym.i] = sym.symbol
       })
-      const parsed = path.parse(file)
-      const dest = path.join(parsed.dir, parsed.name + '_symbolicated' + parsed.ext)
-      fs.writeFileSync(dest, split.join('\n'))
-
-      callback(null, dest)
+      callback(null, split)
     })
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,18 +6,23 @@ const path = require('path')
 const {describe, it} = global
 
 describe('atos', function () {
+  after(() => {
+    output_files.map((file) => fs.unlinkSync(file))
+  })
+
   this.timeout(60000)
 
   const fixtures = path.join(__dirname, 'fixtures')
-
+  let output_files = []
   it('returns an array of symbols for an Electron framework address', (done) => {
     atos({
       file: path.join(fixtures, 'framework-addresses.txt'),
       version: '1.4.14'
-    }, (error, symbols) => {
+    }, (error, output) => {
       if (error != null) return done(error)
 
-      assert.equal(symbols.join('\n'), fs.readFileSync(path.join(fixtures, 'framework-symbols.txt'), 'utf8').trim())
+      output_files.push(output)
+      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'framework-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -26,10 +31,11 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'node-addresses.txt'),
       version: '1.4.14'
-    }, (error, symbols) => {
+    }, (error, output) => {
       if (error != null) return done(error)
 
-      assert.equal(symbols.join('\n'), fs.readFileSync(path.join(fixtures, 'node-symbols.txt'), 'utf8').trim())
+      output_files.push(output)
+      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'node-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -38,10 +44,11 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'mixed-addresses.txt'),
       version: '1.4.14'
-    }, (error, symbols) => {
+    }, (error, output) => {
       if (error != null) return done(error)
 
-      assert.equal(symbols.join('\n'), fs.readFileSync(path.join(fixtures, 'mixed-symbols.txt'), 'utf8').trim())
+      output_files.push(output)
+      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'mixed-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -50,10 +57,11 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'sampling-addresses.txt'),
       version: '1.6.8'
-    }, (error, symbols) => {
+    }, (error, output) => {
       if (error != null) return done(error)
 
-      assert.equal(symbols.join('\n'), fs.readFileSync(path.join(fixtures, 'sampling-symbols.txt'), 'utf8').trim())
+      output_files.push(output)
+      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'sampling-symbols.txt'), 'utf8').trim())
       done()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -6,23 +6,18 @@ const path = require('path')
 const {describe, it} = global
 
 describe('atos', function () {
-  after(() => {
-    output_files.map((file) => fs.unlinkSync(file))
-  })
-
   this.timeout(60000)
 
   const fixtures = path.join(__dirname, 'fixtures')
-  let output_files = []
+
   it('returns an array of symbols for an Electron framework address', (done) => {
     atos({
       file: path.join(fixtures, 'framework-addresses.txt'),
       version: '1.4.14'
-    }, (error, output) => {
+    }, (error, symbols) => {
       if (error != null) return done(error)
 
-      output_files.push(output)
-      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'framework-symbols.txt'), 'utf8').trim())
+      assert.equal(symbols.join('\n').trim(), fs.readFileSync(path.join(fixtures, 'framework-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -31,11 +26,10 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'node-addresses.txt'),
       version: '1.4.14'
-    }, (error, output) => {
+    }, (error, symbols) => {
       if (error != null) return done(error)
 
-      output_files.push(output)
-      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'node-symbols.txt'), 'utf8').trim())
+      assert.equal(symbols.join('\n').trim(), fs.readFileSync(path.join(fixtures, 'node-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -44,11 +38,10 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'mixed-addresses.txt'),
       version: '1.4.14'
-    }, (error, output) => {
+    }, (error, symbols) => {
       if (error != null) return done(error)
 
-      output_files.push(output)
-      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'mixed-symbols.txt'), 'utf8').trim())
+      assert.equal(symbols.join('\n').trim(), fs.readFileSync(path.join(fixtures, 'mixed-symbols.txt'), 'utf8').trim())
       done()
     })
   })
@@ -57,11 +50,10 @@ describe('atos', function () {
     atos({
       file: path.join(fixtures, 'sampling-addresses.txt'),
       version: '1.6.8'
-    }, (error, output) => {
+    }, (error, symbols) => {
       if (error != null) return done(error)
 
-      output_files.push(output)
-      assert.equal(fs.readFileSync(output, 'utf8').trim(), fs.readFileSync(path.join(fixtures, 'sampling-symbols.txt'), 'utf8').trim())
+      assert.equal(symbols.join('\n').trim(), fs.readFileSync(path.join(fixtures, 'sampling-symbols.txt'), 'utf8').trim())
       done()
     })
   })


### PR DESCRIPTION
This change generates a final report by replacing the stack traces in the original report with the symbolicated in the new one.